### PR TITLE
Token refresh

### DIFF
--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/config/AllowedEndpoints.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/config/AllowedEndpoints.java
@@ -1,0 +1,10 @@
+package com.weekendwarriors.weekend_warriors_backend.config;
+
+public class AllowedEndpoints {
+    public static final String[] PUBLIC_URLS = {
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/api/v1/auth/**",
+    };
+}

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/config/SecurityConfig.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/config/SecurityConfig.java
@@ -1,56 +1,55 @@
-package com.weekendwarriors.weekend_warriors_backend.config;
+    package com.weekendwarriors.weekend_warriors_backend.config;
 
-import com.weekendwarriors.weekend_warriors_backend.util.JWTAuthenticationFilter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationProvider;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+    import com.weekendwarriors.weekend_warriors_backend.util.JWTAuthenticationFilter;
+    import lombok.RequiredArgsConstructor;
+    import org.springframework.context.annotation.Bean;
+    import org.springframework.context.annotation.Configuration;
+    import org.springframework.security.authentication.AuthenticationProvider;
+    import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+    import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+    import org.springframework.security.config.http.SessionCreationPolicy;
+    import org.springframework.security.web.SecurityFilterChain;
+    import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+    import org.springframework.web.cors.CorsConfiguration;
+    import org.springframework.web.cors.CorsConfigurationSource;
+    import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.List;
+    import java.util.List;
 
-@Configuration
-@EnableWebSecurity
-@RequiredArgsConstructor
-public class SecurityConfig {
-    private final JWTAuthenticationFilter jwtAuthFilter;
-    private final AuthenticationProvider authenticationProvider;
+    @Configuration
+    @EnableWebSecurity
+    @RequiredArgsConstructor
+    public class SecurityConfig {
+        private final JWTAuthenticationFilter jwtAuthFilter;
+        private final AuthenticationProvider authenticationProvider;
 
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration config = new CorsConfiguration();
-        config.setAllowCredentials(true);
-        config.setAllowedOrigins(List.of("http://localhost:3000")); // Replace with frontend URL
-        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // Allow necessary methods
-        config.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With"));
+        @Bean
+        public CorsConfigurationSource corsConfigurationSource() {
+            CorsConfiguration config = new CorsConfiguration();
+            config.setAllowCredentials(true);
+            config.setAllowedOrigins(List.of("http://localhost:3000")); // Replace with frontend URL
+            config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // Allow necessary methods
+            config.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With"));
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", config);
-        return source;
+            UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+            source.registerCorsConfiguration("/**", config);
+            return source;
+        }
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            http
+                    .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                    .csrf(csrf -> csrf.disable())
+                    .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    .authenticationProvider(authenticationProvider)
+                    .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                    .authorizeHttpRequests(authorize -> authorize
+                            .requestMatchers(AllowedEndpoints.PUBLIC_URLS).permitAll()
+                            .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll() // Allow OPTIONS requests for CORS preflight
+                            .anyRequest().authenticated()
+                    );
+
+            return http.build();
+        }
     }
-
-    @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(csrf -> csrf.disable())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authenticationProvider(authenticationProvider)
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
-                .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
-                        .requestMatchers("/api/v1/auth/register", "/api/v1/auth/login").permitAll()
-                        .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll() // Allow OPTIONS requests for CORS preflight
-                        .anyRequest().authenticated()
-                );
-
-        return http.build();
-    }
-}

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/controller/AuthenticationController.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/controller/AuthenticationController.java
@@ -74,6 +74,22 @@ public class AuthenticationController {
         return ResponseEntity.status(HttpStatus.OK).body(responseBody);
     }
 
+    @Operation(summary = "Refresh the access and refresh tokens for an authenticated user",
+            description = "Generates new access and refresh tokens using the provided refresh token. If the refresh token is valid, the old refresh token is revoked, and a new one is issued.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Access and refresh tokens successfully refreshed",
+                    content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+            @ApiResponse(responseCode = "400",
+                    description = "Incorrect input",
+                    content = @Content(schema = @Schema(implementation = Map.class))),
+            @ApiResponse(responseCode = "401",
+                    description = "Unauthorized - Invalid or expired refresh token",
+                    content = @Content(schema = @Schema(implementation = Map.class))),
+            @ApiResponse(responseCode = "500",
+                    description = "Internal server error - Could not process the token refresh request",
+                    content = @Content(schema = @Schema(implementation = String.class)))
+    })
     @PostMapping("/refresh-token")
     public ResponseEntity<Map<String, TokenResponse>> refreshToken(@Valid @RequestBody RefreshTokenRequest refreshToken) throws InvalidToken {
         Map<String, TokenResponse> responseBody = new HashMap<>();

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/controller/AuthenticationController.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/controller/AuthenticationController.java
@@ -1,16 +1,17 @@
 package com.weekendwarriors.weekend_warriors_backend.controller;
 
 import com.weekendwarriors.weekend_warriors_backend.dto.AuthenticationWithCredentialsRequest;
+import com.weekendwarriors.weekend_warriors_backend.dto.RefreshTokenRequest;
 import com.weekendwarriors.weekend_warriors_backend.dto.RegisterWithCredentialsRequest;
+import com.weekendwarriors.weekend_warriors_backend.dto.TokenResponse;
 import com.weekendwarriors.weekend_warriors_backend.exception.ExistingUser;
+import com.weekendwarriors.weekend_warriors_backend.exception.InvalidToken;
 import com.weekendwarriors.weekend_warriors_backend.exception.UserNotFound;
 import com.weekendwarriors.weekend_warriors_backend.service.AuthenticationWithCredentialsService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -22,9 +23,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -47,20 +46,9 @@ public class AuthenticationController {
                     content = @Content(schema = @Schema(implementation = String.class)))
     })
     @PostMapping("/register")
-    public ResponseEntity<Map<String, Object>> register(@Valid @RequestBody RegisterWithCredentialsRequest registerData, BindingResult bindingResult) throws ExistingUser {
-        if (bindingResult.hasErrors()) {
-            Map<String, Object> responseBody = new HashMap<>();
-            responseBody.put("error", "Incorrect input");
-            List<String> errorMessages = new ArrayList<>();
-            for (ObjectError error : bindingResult.getAllErrors()) {
-                errorMessages.add(error.getDefaultMessage());
-            }
-            responseBody.put("details", errorMessages);
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseBody);
-        }
-
+    public ResponseEntity<Map<String, String>> register(@Valid @RequestBody RegisterWithCredentialsRequest registerData) throws ExistingUser {
         authenticationService.register(registerData);
-        Map<String, Object> responseBody = new HashMap<>();
+        Map<String, String> responseBody = new HashMap<>();
         responseBody.put("message", "Successful register");
         return ResponseEntity.status(HttpStatus.CREATED).body(responseBody);
     }
@@ -79,21 +67,17 @@ public class AuthenticationController {
                     content = @Content(schema = @Schema(implementation = String.class)))
     })
     @PostMapping("/login")
-    public ResponseEntity<Map<String, Object>> login(@Valid @RequestBody AuthenticationWithCredentialsRequest loginData, BindingResult bindingResult) throws UserNotFound {
-        if (bindingResult.hasErrors()) {
-            Map<String, Object> responseBody = new HashMap<>();
-            responseBody.put("error", "Incorrect input");
-            List<String> errorMessages = new ArrayList<>();
-            for (ObjectError error : bindingResult.getAllErrors()) {
-                errorMessages.add(error.getDefaultMessage());
-            }
-            responseBody.put("details", errorMessages);
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseBody);
-        }
-
+    public ResponseEntity<Map<String, Object>> login(@Valid @RequestBody AuthenticationWithCredentialsRequest loginData) throws UserNotFound {
         Map<String, Object> responseBody = new HashMap<>();
         responseBody.put("message", "Successful login");
         responseBody.put("token", authenticationService.login(loginData));
+        return ResponseEntity.status(HttpStatus.OK).body(responseBody);
+    }
+
+    @PostMapping("/refresh-token")
+    public ResponseEntity<Map<String, TokenResponse>> refreshToken(@Valid @RequestBody RefreshTokenRequest refreshToken) throws InvalidToken {
+        Map<String, TokenResponse> responseBody = new HashMap<>();
+        responseBody.put("token", authenticationService.refreshToken(refreshToken));
         return ResponseEntity.status(HttpStatus.OK).body(responseBody);
     }
 }

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/dto/RefreshTokenRequest.java
@@ -1,0 +1,14 @@
+package com.weekendwarriors.weekend_warriors_backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class RefreshTokenRequest {
+    @NotBlank(message = "Refresh token is required")
+    String refreshToken;
+}

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/exception/GlobalExceptionHandler.java
@@ -2,11 +2,16 @@ package com.weekendwarriors.weekend_warriors_backend.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @ControllerAdvice
@@ -26,6 +31,28 @@ public class GlobalExceptionHandler {
         Map<String, String> responseBody = new HashMap<>();
         responseBody.put("error", exception.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(responseBody);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Map<String, Object>> handleValidationErrors(MethodArgumentNotValidException exception) {
+        BindingResult bindingResult = exception.getBindingResult();
+
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("error", "Incorrect input");
+        List<String> errorMessages = new ArrayList<>();
+        for (ObjectError error : bindingResult.getAllErrors()) {
+            errorMessages.add(error.getDefaultMessage());
+        }
+        responseBody.put("details", errorMessages);
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(responseBody);
+    }
+
+    @ExceptionHandler(InvalidToken.class)
+    public ResponseEntity<Map<String, Object>> handleInvalidTokenErrors(InvalidToken exception) {
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("error", exception.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(responseBody);
     }
 
     @ExceptionHandler(IOException.class)

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/exception/InvalidToken.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/exception/InvalidToken.java
@@ -1,0 +1,7 @@
+package com.weekendwarriors.weekend_warriors_backend.exception;
+
+public class InvalidToken extends RuntimeException {
+    public InvalidToken(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/service/AuthenticationWithCredentialsService.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/service/AuthenticationWithCredentialsService.java
@@ -1,16 +1,17 @@
 package com.weekendwarriors.weekend_warriors_backend.service;
 
 import com.weekendwarriors.weekend_warriors_backend.dto.AuthenticationWithCredentialsRequest;
+import com.weekendwarriors.weekend_warriors_backend.dto.RefreshTokenRequest;
 import com.weekendwarriors.weekend_warriors_backend.dto.RegisterWithCredentialsRequest;
 import com.weekendwarriors.weekend_warriors_backend.dto.TokenResponse;
-import com.weekendwarriors.weekend_warriors_backend.enums.JWTTokenType;
 import com.weekendwarriors.weekend_warriors_backend.enums.UserRole;
 import com.weekendwarriors.weekend_warriors_backend.exception.ExistingUser;
+import com.weekendwarriors.weekend_warriors_backend.exception.InvalidToken;
 import com.weekendwarriors.weekend_warriors_backend.exception.UserNotFound;
 import com.weekendwarriors.weekend_warriors_backend.model.Token;
 import com.weekendwarriors.weekend_warriors_backend.model.User;
-import com.weekendwarriors.weekend_warriors_backend.repository.TokenRepository;
 import com.weekendwarriors.weekend_warriors_backend.repository.UserRepository;
+import io.jsonwebtoken.ExpiredJwtException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
@@ -22,10 +23,10 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class AuthenticationWithCredentialsService {
     private final UserRepository userRepository;
-    private final TokenRepository tokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JWTBearerService jwtBearerService;
     private final AuthenticationManager authenticationManager;
+    private final RefreshTokenService refreshTokenService;
 
     public void register(RegisterWithCredentialsRequest registerData) throws ExistingUser {
         if (userRepository.findByEmail(registerData.getEmail()).isPresent())
@@ -52,18 +53,33 @@ public class AuthenticationWithCredentialsService {
         User user = userRepository.findByEmail(loginData.getEmail()).orElseThrow(() -> new UserNotFound("Invalid credentials provided"));
         String accessToken = jwtBearerService.generateAccessToken(user.getId());
         String refreshToken = jwtBearerService.generateRefreshToken(user.getId());
-        saveRefreshTokenForUser(user, refreshToken);
+        refreshTokenService.saveRefreshTokenForUser(user, refreshToken);
         return new TokenResponse(accessToken, refreshToken);
     }
 
-    private void saveRefreshTokenForUser(User user, String refreshToken) {
-        var token = Token.builder()
-                .user(user)
-                .token(refreshToken)
-                .type(JWTTokenType.REFRESH)
-                .expired(false)
-                .revoked(false)
-                .build();
-        tokenRepository.save(token);
+    public TokenResponse refreshToken(RefreshTokenRequest refreshTokenRequest) throws InvalidToken {
+        String refreshToken = refreshTokenRequest.getRefreshToken();
+        try {
+            String subject = jwtBearerService.extractSubject(refreshToken);
+
+            User user = userRepository.findById(subject).orElseThrow(() -> new InvalidToken("Invalid token"));
+
+            if (!refreshTokenService.isRefreshTokenValid(refreshToken, subject))
+                throw new InvalidToken("Invalid refresh token");
+
+            Token oldRefreshToken = refreshTokenService.findByToken(refreshToken)
+                    .orElseThrow(() -> new InvalidToken("Invalid refresh token"));
+            refreshTokenService.revokeToken(oldRefreshToken);
+
+            String newAccessToken = jwtBearerService.generateAccessToken(subject);
+            String newRefreshToken = jwtBearerService.generateRefreshToken(subject);
+
+            refreshTokenService.saveRefreshTokenForUser(user, newRefreshToken);
+
+            return new TokenResponse(newAccessToken, newRefreshToken);
+        }
+        catch (ExpiredJwtException exception) {
+            throw new InvalidToken("Invalid refresh token");
+        }
     }
 }

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/service/RefreshTokenService.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/service/RefreshTokenService.java
@@ -1,0 +1,46 @@
+package com.weekendwarriors.weekend_warriors_backend.service;
+
+import com.weekendwarriors.weekend_warriors_backend.enums.JWTTokenType;
+import com.weekendwarriors.weekend_warriors_backend.model.Token;
+import com.weekendwarriors.weekend_warriors_backend.model.User;
+import com.weekendwarriors.weekend_warriors_backend.repository.TokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final TokenRepository tokenRepository;
+    private final JWTBearerService jwtBearerService;
+
+    public void saveRefreshTokenForUser(User user, String refreshToken) {
+        var token = Token.builder()
+                .user(user)
+                .token(refreshToken)
+                .type(JWTTokenType.REFRESH)
+                .expired(false)
+                .revoked(false)
+                .build();
+        tokenRepository.save(token);
+    }
+
+    public void revokeToken(Token token) {
+        token.setRevoked(true);
+        tokenRepository.save(token);
+    }
+
+    public Optional<Token> findByToken(String token) {
+        return tokenRepository.findByToken(token);
+    }
+
+    public boolean isRefreshTokenValid(String refreshToken, String subject) {
+        var token = tokenRepository.findByToken(refreshToken);
+        if(token.isPresent()) {
+            if(token.get().getType() == JWTTokenType.REFRESH && !token.get().isExpired() && !token.get().isRevoked())
+                return jwtBearerService.isTokenValid(refreshToken, subject);
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/util/JWTAuthenticationFilter.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/util/JWTAuthenticationFilter.java
@@ -1,13 +1,16 @@
 package com.weekendwarriors.weekend_warriors_backend.util;
 
+import com.weekendwarriors.weekend_warriors_backend.config.AllowedEndpoints;
 import com.weekendwarriors.weekend_warriors_backend.enums.JWTTokenType;
 import com.weekendwarriors.weekend_warriors_backend.service.CustomUserDetailsService;
 import com.weekendwarriors.weekend_warriors_backend.service.JWTBearerService;
+import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.lang.NonNull;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,6 +20,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.regex.Pattern;
 
 @Component
 @RequiredArgsConstructor
@@ -24,37 +29,68 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
     private final JWTBearerService jwtBearerService;
     private final CustomUserDetailsService userDetailsService;
 
+    private void writeErrorResponse(HttpServletResponse response, HttpStatus status, String errorMessage) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.getWriter().write(String.format("{\"error\": \"%s\"}", errorMessage));
+    }
+
+    private Pattern[] convertPublicUrlsToPatterns() {
+        return Arrays.stream(AllowedEndpoints.PUBLIC_URLS)
+                .map(url -> url.replace("/**", "(/.*)?"))
+                .map(url -> Pattern.compile("^" + url + "$"))
+                .toArray(Pattern[]::new);
+    }
+
     @Override
     protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain) throws ServletException, IOException {
         final String authHeader = request.getHeader("Authorization");
         final String jwt;
         final String userId;
 
-        if(authHeader == null || !authHeader.startsWith("Bearer "))
-        {
-            filterChain.doFilter(request,response);
+        boolean isPublicUrl = Arrays.stream(convertPublicUrlsToPatterns())
+                .anyMatch(pattern -> pattern.matcher(request.getRequestURI()).matches());
+
+        if (isPublicUrl) {
+            filterChain.doFilter(request, response);
             return;
         }
 
-        jwt = authHeader.substring(7);
-        userId = jwtBearerService.extractSubject(jwt);
-        JWTTokenType tokenType = jwtBearerService.extractTokenType(jwt);
-
-        if (userId != null && tokenType == JWTTokenType.ACCESS && SecurityContextHolder.getContext().getAuthentication() == null)
+        if(authHeader == null || !authHeader.startsWith("Bearer "))
         {
-            UserDetails userDetails = userDetailsService.loadUserById(userId);
-
-            if (jwtBearerService.isTokenValid(jwt, userId))
-            {
-                UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
-                        userDetails,
-                        null,
-                        userDetails.getAuthorities()
-                );
-                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContextHolder.getContext().setAuthentication(authToken);
-            }
+            this.writeErrorResponse(response, HttpStatus.BAD_REQUEST, "Authorization header is missing or invalid");
+            return;
         }
-        filterChain.doFilter(request,response);
+
+        try
+        {
+            jwt = authHeader.substring(7);
+            userId = jwtBearerService.extractSubject(jwt);
+            JWTTokenType tokenType = jwtBearerService.extractTokenType(jwt);
+
+            if (userId != null && tokenType == JWTTokenType.ACCESS && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = userDetailsService.loadUserById(userId);
+
+                if (jwtBearerService.isTokenValid(jwt, userId)) {
+                    UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(
+                            userDetails,
+                            null,
+                            userDetails.getAuthorities()
+                    );
+                    authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(authToken);
+                }
+                else {
+                    this.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "JWT token is invalid");
+                    return;
+                }
+            }
+            filterChain.doFilter(request, response);
+        }
+        catch (ExpiredJwtException ex) {
+            this.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "JWT token has expired");
+        } catch (Exception e) {
+            this.writeErrorResponse(response, HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred");
+        }
     }
 }

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/util/JWTAuthenticationFilter.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/util/JWTAuthenticationFilter.java
@@ -79,13 +79,12 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
                     );
                     authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                     SecurityContextHolder.getContext().setAuthentication(authToken);
-                }
-                else {
-                    this.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "JWT token is invalid");
+
+                    filterChain.doFilter(request, response);
                     return;
                 }
             }
-            filterChain.doFilter(request, response);
+            this.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "JWT token is invalid");
         }
         catch (ExpiredJwtException ex) {
             this.writeErrorResponse(response, HttpStatus.UNAUTHORIZED, "JWT token has expired");


### PR DESCRIPTION
This PR adds a POST '/refresh-token' endpoint for refreshing user authentication tokens. It allows users to obtain a new access token and refresh token using a valid refresh token. Invalid or expired tokens return a 401 Unauthorized error.

1. Refresh Token Endpoint in controller:
- a new POST '/refresh-token' endpoint is added in AuthenticationController. It accepts a refresh token in the request body and returns a new access token and refresh token if the provided token is valid.

2. RefreshTokenService class:
- this class handles refresh token helper methods for token revocation, checking the validity of a refresh token, finding the associated token model of a refresh token in the repository and saving the refresh token for a user

3. Changes in AuthenticationWithCredentialsService class:
- a new method for the refresh token functionality is added. This method validates the given refresh token, throws InvalidToken exception in case of invalid or expired tokens, revokes the old refresh token and generates new access and refresh tokens

4. AllowedEndpoints class
- the endpoints that do not need authorization are stored here and used in the SecurityConfig and JWTAuthenticationFilter classes

5. Changes in SecurityConfig
- the allowed public endpoints are taken from the AllowedEndpoints class

6. Changes in JWTAuthenticationFilter
- added specific error messages for cases like missing authorization headers for protected endpoints and expired or invalid access tokens

7. Tests for POST '/refresh-token' endpoint
- tested the endpoint for valid and invalid refresh tokens