### PR TITLE
Logout endpoint

### DIFF
--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/config/AllowedEndpoints.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/config/AllowedEndpoints.java
@@ -5,6 +5,8 @@ public class AllowedEndpoints {
             "/v3/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
-            "/api/v1/auth/**",
+            "/api/v1/auth/login",
+            "/api/v1/auth/register",
+            "/api/v1/auth/refresh-token",
     };
 }

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/controller/AuthenticationController.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/controller/AuthenticationController.java
@@ -96,4 +96,12 @@ public class AuthenticationController {
         responseBody.put("token", authenticationService.refreshToken(refreshToken));
         return ResponseEntity.status(HttpStatus.OK).body(responseBody);
     }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Map<String, String>> logout(@Valid @RequestBody RefreshTokenRequest refreshToken) {
+        Map<String, String> responseBody = new HashMap<>();
+        authenticationService.logout(refreshToken);
+        responseBody.put("message", "Successful logout");
+        return ResponseEntity.status(HttpStatus.OK).body(responseBody);
+    }
 }

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/controller/AuthenticationController.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/controller/AuthenticationController.java
@@ -97,6 +97,22 @@ public class AuthenticationController {
         return ResponseEntity.status(HttpStatus.OK).body(responseBody);
     }
 
+    @Operation(summary = "Logout the authenticated user",
+            description = "Logs out the user by invalidating the provided refresh token. If the refresh token is valid, it will be revoked to prevent further use.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "User successfully logged out",
+                    content = @Content(schema = @Schema(implementation = TokenResponse.class))),
+            @ApiResponse(responseCode = "400",
+                    description = "Bad Request - Invalid input",
+                    content = @Content(schema = @Schema(implementation = Map.class))),
+            @ApiResponse(responseCode = "401",
+                    description = "Unauthorized - Invalid or expired refresh token",
+                    content = @Content(schema = @Schema(implementation = Map.class))),
+            @ApiResponse(responseCode = "500",
+                    description = "Internal server error - Could not process the logout request",
+                    content = @Content(schema = @Schema(implementation = String.class)))
+    })
     @PostMapping("/logout")
     public ResponseEntity<Map<String, String>> logout(@Valid @RequestBody RefreshTokenRequest refreshToken) {
         Map<String, String> responseBody = new HashMap<>();

--- a/src/main/java/com/weekendwarriors/weekend_warriors_backend/service/AuthenticationWithCredentialsService.java
+++ b/src/main/java/com/weekendwarriors/weekend_warriors_backend/service/AuthenticationWithCredentialsService.java
@@ -82,4 +82,22 @@ public class AuthenticationWithCredentialsService {
             throw new InvalidToken("Invalid refresh token");
         }
     }
+
+    public void logout(RefreshTokenRequest refreshTokenRequest){
+        String refreshToken = refreshTokenRequest.getRefreshToken();
+        try
+        {
+            String subject = jwtBearerService.extractSubject(refreshToken);
+
+            if (!refreshTokenService.isRefreshTokenValid(refreshToken, subject))
+                throw new InvalidToken("Invalid refresh token");
+
+            Token databaseRefreshToken = refreshTokenService.findByToken(refreshToken)
+                    .orElseThrow(() -> new InvalidToken("Invalid refresh token"));
+            refreshTokenService.revokeToken(databaseRefreshToken);
+        }
+        catch (ExpiredJwtException exception) {
+            throw new InvalidToken("Invalid refresh token");
+        }
+    }
 }


### PR DESCRIPTION
Overview: 

This pull request implements a logout functionality for the authenticated user by invalidating the provided refresh token. The feature ensures that a valid refresh token is revoked, preventing its further use. If the provided refresh token is expired or invalid, an appropriate error response will be returned.

Details:

1. Logout method in AuthenticationController:

- A POST endpoint /logout has been added to handle the user logout request.
- The method accepts a RefreshTokenRequest containing the refresh token to be invalidated.
- The service layer method logout processes the request by extracting the subject from the refresh token, validating it, and revoking the associated token if valid.
- If the token is expired or invalid, the service throws an InvalidToken exception, which is handled to return a 401 Unauthorized response.

2. Documented POST /logout endpoint

- 200 OK: Returned when the user is successfully logged out, and the refresh token is revoked. The response includes the message "Successful logout".
- 400 Bad Request: Returned when the input is invalid (e.g., missing or malformed refresh token).
- 401 Unauthorized: Returned when the refresh token is invalid or expired.
- 500 Internal Server Error: Returned in case of any internal errors during the logout process.

3. Logout method in AuthenticationWithCredentialsService:

- handles the core functionality of invalidating the refresh token and revoking it, ensuring that the user is successfully logged out
- performs token validation, token extraction, and manages the token revocation process.
- throws appropriate exceptions for edge cases
